### PR TITLE
log_info wasn't found on my mac

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -72,7 +72,7 @@ download_release() {
   name=${TOOL_NAME}_${version}_${os}_${arch}
   case ${platform} in
     darwin/arm64)
-      log_info "Platform ${platform} (m1 silicon) detected, using compatible darwin/amd64 binary instead."
+      echo "Platform ${platform} (m1 silicon) detected, using compatible darwin/amd64 binary instead."
       name=${TOOL_NAME}_${version}_${os}_amd64
       ;;
   esac


### PR DESCRIPTION
Hey!

When I installed this on my new computer (which is darwin), I got an error about `log_info` not existing. I just switched it quickly to `echo` and it works fine now for me.

Thanks for writing this up back in the day, it's something I use in my daily workflow <3